### PR TITLE
Error: connect ENETUNREACH 223.5.5.5:853 ,Emitted 'error' event on TLSSocket instance at:

### DIFF
--- a/src/dnstls.ts
+++ b/src/dnstls.ts
@@ -128,7 +128,7 @@ export function query(...args: any[]): Promise<IDnsResponse> {
     const dnsQueryBuf = dnsPacket.streamEncode(dnsQuery);
 
     const socket = connect({ host, servername, port });
-
+    socket.on('error',reject)
     socket.on('secureConnect', () => socket.write(dnsQueryBuf));
 
     socket.on('data', (data: Buffer) => {


### PR DESCRIPTION
Error: connect ENETUNREACH 223.5.5.5:853 ,Emitted 'error' event on TLSSocket instance at:

fix bug This causes the program to exit directly instead of returning a rejected promise.